### PR TITLE
Async Init

### DIFF
--- a/lib/rmq.module.ts
+++ b/lib/rmq.module.ts
@@ -9,7 +9,9 @@ export class RMQModule {
 		const rmqServiceProvider = {
 			provide: RMQService,
 			useFactory: async (): Promise<RMQService> => {
-				return new RMQService(options);
+				const service = new RMQService(options);
+				await service.init();
+				return service;
 			},
 		};
 		return {


### PR DESCRIPTION
This PR changes the way RMQ Service is provided. 

### Problem:
It is very painfull during tests execution:
```
app = moduleFixture.createNestApplication();
await app.init();
NEST APP IS LIVE NOW, BUT IT IS NOT READY TO OPERATE, SINCE CONNECTION TO RABBIT MAY NOT BE ESTABLISHED YET
```

### Plans:

I would like to prepare separate Connection class and factory, similar as it is done in @nestjs/mognoose package. For now, I am proposing smaller and faster solution.

### Before:
The init() method establishing the connection is called inside the constructor in async way. The RMQService may be provided, but not ready to operate.
```
[Nest] 26975   - 04/16/2020, 10:42:51 PM   [NestFactory] Starting Nest application...
[4/16/2020] [10:42:51 PM] › …  watching  Connecting to RMQ
[Nest] 26975   - 04/16/2020, 10:42:51 PM   [InstanceLoader] RMQModule dependencies initialized +30ms
[Nest] 26975   - 04/16/2020, 10:42:51 PM   [InstanceLoader] AppModule dependencies initialized +0ms
[Nest] 26975   - 04/16/2020, 10:42:51 PM   [RoutesResolver] AppController {}: +6ms
[Nest] 26975   - 04/16/2020, 10:42:51 PM   [RouterExplorer] Mapped {, GET} route +3ms
[Nest] 26975   - 04/16/2020, 10:42:51 PM   [NestApplication] Nest application successfully started +2ms
**| NEST APP IS LIVE HERE BUT NOT READY !! |**
[4/16/2020] [10:42:51 PM] › ✔  success   Successfully connected to RMQ
 ```
### After:
The init method is called sync inside the provider factory. When the connection is sucessfuly established, the provider is resolved.
```
[Nest] 2818   - 04/17/2020, 8:20:48 AM   [NestFactory] Starting Nest application...
[4/17/2020] [8:20:48 AM] › …  watching  Connecting to RMQ
[Nest] 2818   - 04/17/2020, 8:20:48 AM   [InstanceLoader] AppModule dependencies initialized +62ms
[4/17/2020] [8:20:48 AM] › ✔  success   Successfully connected to RMQ
[Nest] 2818   - 04/17/2020, 8:20:48 AM   [InstanceLoader] RMQModule dependencies initialized +85ms
[Nest] 2818   - 04/17/2020, 8:20:48 AM   [NestApplication] Nest application successfully started +6ms
**| NEST APP IS LIVE AND READY !! |**
```