### PR TITLE
Add Controller Options & Msg Factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## 1.9.0
+-   Custom message factory inside controller decorator (thx to mjarmoc)
+
 ## 1.8.0
 -   Messages publishing options exposed (thx to mjarmoc)
 

--- a/lib/decorators/rmq-controller.decorator.ts
+++ b/lib/decorators/rmq-controller.decorator.ts
@@ -1,32 +1,37 @@
-import {
-	ERROR_NO_ROUTE_FOR_CONTROLLER, ERROR_TYPE,
-	ERROR_UNDEFINED_FROM_RPC,
-	RMQ_ROUTES_META,
-} from '../constants';
+import { Logger } from '@nestjs/common';
+
+import { ERROR_NO_ROUTE_FOR_CONTROLLER, ERROR_TYPE, ERROR_UNDEFINED_FROM_RPC, RMQ_ROUTES_META } from '../constants';
 import { IQueueMeta } from '../interfaces/queue-meta.interface';
 import { requestEmitter, responseEmitter, ResponseEmmiterResult } from '../emmiters/router.emmiter';
 import { RMQService } from '../rmq.service';
 import { Message } from 'amqplib';
 import { RMQError } from '..';
-import { Logger } from '@nestjs/common';
+import { IRMQControllerOptions } from '../interfaces/rmq-controller-options.interface';
 
-export function RMQController(): ClassDecorator {
-	return function(target: any) {
+export const RMQMessageFactory = (msg: Message, topic: IQueueMeta) => {
+	return [JSON.parse(msg.content.toString())];
+};
+
+export function RMQController(options?: IRMQControllerOptions): ClassDecorator {
+	return function (target: any) {
 		let topics: IQueueMeta[] = Reflect.getMetadata(RMQ_ROUTES_META, RMQService);
-		topics = topics ? topics.filter(topic => topic.target === target.prototype) : [];
-		if(topics.length === 0) {
+		topics = topics ? topics.filter((topic) => topic.target === target.prototype) : [];
+		if (topics.length === 0) {
 			Logger.error(`${ERROR_NO_ROUTE_FOR_CONTROLLER} ${target.prototype.constructor.name}`);
 		}
-		target = class extends (target as { new(...args): any }) {
+		target = class extends (target as { new (...args): any }) {
 			constructor(...args: any) {
 				super(...args);
-				topics.forEach(async topic => {
+				topics.forEach(async (topic) => {
 					requestEmitter.on(topic.topic, async (msg: Message) => {
 						try {
-							const result = await this[topic.methodName](JSON.parse(msg.content.toString()));
+							const result = await this[topic.methodName].apply(
+								this,
+								options?.msgFactory ? options.msgFactory(msg, topic) : RMQMessageFactory(msg, topic)
+							);
 							if (msg.properties.replyTo && result) {
 								responseEmitter.emit(ResponseEmmiterResult.success, msg, result);
-							} else if(msg.properties.replyTo && result === undefined) {
+							} else if (msg.properties.replyTo && result === undefined) {
 								responseEmitter.emit(
 									ResponseEmmiterResult.error,
 									msg,

--- a/lib/interfaces/rmq-controller-options.interface.ts
+++ b/lib/interfaces/rmq-controller-options.interface.ts
@@ -1,0 +1,6 @@
+import { Message } from 'amqplib';
+import { IQueueMeta } from './queue-meta.interface';
+
+export interface IRMQControllerOptions {
+	msgFactory?: (msg: Message, topic: IQueueMeta) => any[];
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nestjs-rmq",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"description": "NestJS RabbitMQ Module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
This PR introduces a possibility to add params to RMQController decorator.

The first application is a possibility to provide custom msg factory. We use it to call RMQRoute event handler with two arguments: Payload & Context instead of one (msg). In a custom factory, you may define n parameters and provide custom params decorator for them. This does not conflict with middleware/interceptors since it does not process the `msg` (and propagation to listeners/emitters) but the way `msg` is applied to the route handler function in the controller.