### PR TITLE
Feature/allow exchange assert options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Additionally, you can use optional parameters:
 -   **messagesTimeout** (number) - Number of milliseconds 'post' method will wait for the response before a timeout error. Default is 30 000.
 -   **isQueueDurable** (boolean) - Makes created queue durable. Default is true.
 -   **isExchangeDurable** (boolean) - Makes created exchange durable. Default is true.
+-   **exchangeOptions** (Options.AssertExchange) - You can read more about exchange options [here](squaremobius.net/amqp.node/channel_api.html#channel_assertExchange).
 -   **logMessages** (boolean) - Enable printing all sent and recieved messages in console with its route and content. Default is false.
 -   **logger** (LoggerService) - Your custom logger service that implements `LoggerService` interface. Compatible with Winston and other loggers.
 -   **middleware** (array) - Array of middleware functions that extends `RMQPipeClass` with one method `transform`. They will be triggered right after recieving message, before pipes and controller method. Trigger order is equal to array order.
@@ -349,32 +350,28 @@ export class MyController {
 
 You will get info about message, field and properties:
 
-``` json
+```json
 {
-    "fields": {
-        "consumerTag": "amq.ctag-Q-l8A4Oh76cUkIKbHWNZzA",
-        "deliveryTag": 4,
-        "redelivered": false,
-        "exchange": "test",
-        "routingKey": "debug.rpc"
-    },
-    "properties": {
-        "headers": {},
-        "correlationId": "388236ad-6f01-3de5-975d-f9665b73de33",
-        "replyTo": "amq.rabbitmq.reply-to.g1hkABNyYWJiaXRANzQwNDVlYWQ5ZTgwAAAG2AAAAABfmnkW.9X12ySrcM6BOXpGXKkR+Yg==",
-        "timestamp": 1603959908996,
-        "appId": "test-service"
-    },
-    "message": {
-        "prop1": [
-            1
-        ],
-        "prop2": "Buffer - length 11"
-    }
+	"fields": {
+		"consumerTag": "amq.ctag-Q-l8A4Oh76cUkIKbHWNZzA",
+		"deliveryTag": 4,
+		"redelivered": false,
+		"exchange": "test",
+		"routingKey": "debug.rpc"
+	},
+	"properties": {
+		"headers": {},
+		"correlationId": "388236ad-6f01-3de5-975d-f9665b73de33",
+		"replyTo": "amq.rabbitmq.reply-to.g1hkABNyYWJiaXRANzQwNDVlYWQ5ZTgwAAAG2AAAAABfmnkW.9X12ySrcM6BOXpGXKkR+Yg==",
+		"timestamp": 1603959908996,
+		"appId": "test-service"
+	},
+	"message": {
+		"prop1": [1],
+		"prop2": "Buffer - length 11"
+	}
 }
 ```
-
-
 
 ## Customizing massage with msgFactory
 

--- a/lib/interfaces/rmq-options.interface.ts
+++ b/lib/interfaces/rmq-options.interface.ts
@@ -3,6 +3,7 @@ import { RMQIntercepterClass } from '../classes/rmq-intercepter.class';
 import { RMQErrorHandler } from '../classes/rmq-error-handler.class';
 import { LoggerService } from '@nestjs/common';
 import { ModuleMetadata } from '@nestjs/common/interfaces';
+import { Channel, Options } from 'amqplib';
 
 export interface IRMQServiceOptions {
 	exchangeName: string;
@@ -15,6 +16,8 @@ export interface IRMQServiceOptions {
 	isGlobalPrefetchCount?: boolean;
 	isQueueDurable?: boolean;
 	isExchangeDurable?: boolean;
+	assertExchangeType?: Parameters<Channel['assertExchange']>[1];
+	exchangeOptions?: Options.AssertExchange;
 	reconnectTimeInSeconds?: number;
 	heartbeatIntervalInSeconds?: number;
 	messagesTimeout?: number;

--- a/lib/interfaces/rmq-publish-options.interface.ts
+++ b/lib/interfaces/rmq-publish-options.interface.ts
@@ -1,6 +1,4 @@
-export interface IPublishOptions {
-  expiration?: number;
-  priority?: number;
-  persistent?: boolean;
-  timeout?: number;
+import { Options } from 'amqplib';
+export interface IPublishOptions extends Options.Publish {
+	timeout?: number;
 }

--- a/lib/rmq.service.ts
+++ b/lib/rmq.service.ts
@@ -59,9 +59,14 @@ export class RMQService {
 			this.channel = this.server.createChannel({
 				json: false,
 				setup: async (channel: Channel) => {
-					await channel.assertExchange(this.options.exchangeName, 'topic', {
-						durable: this.options.isExchangeDurable ?? true,
-					});
+					await channel.assertExchange(
+						this.options.exchangeName,
+						this.options.assertExchangeType ? this.options.assertExchangeType : 'topic',
+						{
+							...this.options.exchangeOptions,
+							durable: this.options.isExchangeDurable ?? true,
+						}
+					);
 					await channel.prefetch(
 						this.options.prefetchCount ?? DEFAULT_PREFETCH_COUNT,
 						this.options.isGlobalPrefetchCount ?? false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1246,6 +1246,7 @@
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.15.tgz",
       "integrity": "sha512-9ifD1VRO3I85AX3VbcYiD6mV/pv02/ZV2jrxPjHXXFMK49q/2zrWTcyMuZ4ORWSbzqUHUE3tHAY/QagOkIdvog==",
+      "dev": true,
       "requires": {
         "@types/bluebird": "*",
         "@types/node": "*"
@@ -1295,7 +1296,8 @@
     "@types/bluebird": {
       "version": "3.5.33",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.33.tgz",
-      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ=="
+      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ==",
+      "dev": true
     },
     "@types/chalk": {
       "version": "2.2.0",
@@ -1350,7 +1352,8 @@
     "@types/node": {
       "version": "13.9.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.5.tgz",
-      "integrity": "sha512-hkzMMD3xu6BrJpGVLeQ3htQQNAcOrJjX7WFmtK8zWQpz2UJf13LCFF2ALA7c9OVdvc2vQJeDdjfR35M0sBCxvw=="
+      "integrity": "sha512-hkzMMD3xu6BrJpGVLeQ3htQQNAcOrJjX7WFmtK8zWQpz2UJf13LCFF2ALA7c9OVdvc2vQJeDdjfR35M0sBCxvw==",
+      "dev": true
     },
     "@types/prettier": {
       "version": "1.19.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1246,7 +1246,6 @@
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.15.tgz",
       "integrity": "sha512-9ifD1VRO3I85AX3VbcYiD6mV/pv02/ZV2jrxPjHXXFMK49q/2zrWTcyMuZ4ORWSbzqUHUE3tHAY/QagOkIdvog==",
-      "dev": true,
       "requires": {
         "@types/bluebird": "*",
         "@types/node": "*"
@@ -1296,8 +1295,7 @@
     "@types/bluebird": {
       "version": "3.5.33",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.33.tgz",
-      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ==",
-      "dev": true
+      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ=="
     },
     "@types/chalk": {
       "version": "2.2.0",
@@ -1352,8 +1350,7 @@
     "@types/node": {
       "version": "13.9.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.5.tgz",
-      "integrity": "sha512-hkzMMD3xu6BrJpGVLeQ3htQQNAcOrJjX7WFmtK8zWQpz2UJf13LCFF2ALA7c9OVdvc2vQJeDdjfR35M0sBCxvw==",
-      "dev": true
+      "integrity": "sha512-hkzMMD3xu6BrJpGVLeQ3htQQNAcOrJjX7WFmtK8zWQpz2UJf13LCFF2ALA7c9OVdvc2vQJeDdjfR35M0sBCxvw=="
     },
     "@types/prettier": {
       "version": "1.19.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-rmq",
-  "version": "1.13.2",
+  "version": "1.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1243,10 +1243,9 @@
       }
     },
     "@types/amqplib": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.13.tgz",
-      "integrity": "sha512-0r8cJfUajAlcHxlJsZyqRrSAYzv+pJPsaAQjDC6e5rACi3AOIuR0AfevJG7NLvw3Qu4EGhf3KS/ECwd5cUAY2A==",
-      "dev": true,
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.15.tgz",
+      "integrity": "sha512-9ifD1VRO3I85AX3VbcYiD6mV/pv02/ZV2jrxPjHXXFMK49q/2zrWTcyMuZ4ORWSbzqUHUE3tHAY/QagOkIdvog==",
       "requires": {
         "@types/bluebird": "*",
         "@types/node": "*"
@@ -1294,10 +1293,9 @@
       }
     },
     "@types/bluebird": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.28.tgz",
-      "integrity": "sha512-0Vk/kqkukxPKSzP9c8WJgisgGDx5oZDbsLLWIP5t70yThO/YleE+GEm2S1GlRALTaack3O7U5OS5qEm7q2kciA==",
-      "dev": true
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.33.tgz",
+      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ=="
     },
     "@types/chalk": {
       "version": "2.2.0",
@@ -1352,8 +1350,7 @@
     "@types/node": {
       "version": "13.9.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.5.tgz",
-      "integrity": "sha512-hkzMMD3xu6BrJpGVLeQ3htQQNAcOrJjX7WFmtK8zWQpz2UJf13LCFF2ALA7c9OVdvc2vQJeDdjfR35M0sBCxvw==",
-      "dev": true
+      "integrity": "sha512-hkzMMD3xu6BrJpGVLeQ3htQQNAcOrJjX7WFmtK8zWQpz2UJf13LCFF2ALA7c9OVdvc2vQJeDdjfR35M0sBCxvw=="
     },
     "@types/prettier": {
       "version": "1.19.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 	"dependencies": {
 		"amqp-connection-manager": "^3.2.1",
 		"amqplib": "^0.6.0",
-		"@types/amqplib": "^0.5.15",
 		"chalk": "^4.1.0",
 		"class-validator": "^0.12.2",
 		"reflect-metadata": "^0.1.13"
@@ -38,6 +37,7 @@
 		"@nestjs/core": "^7.4.4",
 		"@nestjs/platform-express": "^7.4.4",
 		"@nestjs/testing": "^7.4.4",
+		"@types/amqplib": "^0.5.15",
 		"@types/amqp-connection-manager": "^2.0.9",
 		"@types/chalk": "^2.2.0",
 		"@types/jest": "^25.1.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"amqp-connection-manager": "^3.2.1",
 		"amqplib": "^0.6.0",
+		"@types/amqplib": "^0.5.15",
 		"chalk": "^4.1.0",
 		"class-validator": "^0.12.2",
 		"reflect-metadata": "^0.1.13"
@@ -37,7 +38,6 @@
 		"@nestjs/core": "^7.4.4",
 		"@nestjs/platform-express": "^7.4.4",
 		"@nestjs/testing": "^7.4.4",
-		"@types/amqplib": "^0.5.15",
 		"@types/amqp-connection-manager": "^2.0.9",
 		"@types/chalk": "^2.2.0",
 		"@types/jest": "^25.1.4",


### PR DESCRIPTION
Should not have any breaking changes. I added an optional parameter that allows us to directly write asserExchange options parameters. I also added an extends from the amqplib interfaces to local interface parameters for publish options. 

Also added an optional parameter to set a different exchange type. In my case, this is so that I can set it to x-delayed-message (acts like topic), which will enable support for this plugin: https://github.com/rabbitmq/rabbitmq-delayed-message-exchange .

I ran all tests without issue.