### PR TITLE
An empty string as the queue name is used to generate a random name

### DIFF
--- a/lib/interfaces/rmq-options.interface.ts
+++ b/lib/interfaces/rmq-options.interface.ts
@@ -15,6 +15,7 @@ export interface IRMQServiceOptions {
 	prefetchCount?: number;
 	isGlobalPrefetchCount?: boolean;
 	isQueueDurable?: boolean;
+	isQueueExclusive?: boolean;
 	isExchangeDurable?: boolean;
 	assertExchangeType?: Parameters<Channel['assertExchange']>[1];
 	exchangeOptions?: Options.AssertExchange;

--- a/lib/rmq.service.ts
+++ b/lib/rmq.service.ts
@@ -177,7 +177,7 @@ export class RMQService implements OnModuleInit, IRMQService {
 						this.options.prefetchCount ?? DEFAULT_PREFETCH_COUNT,
 						this.options.isGlobalPrefetchCount ?? false
 					);
-					if (this.options.queueName) {
+					if (typeof this.options.queueName === 'string') {
 						this.listen(channel);
 					}
 					this.logConnected();
@@ -208,10 +208,13 @@ export class RMQService implements OnModuleInit, IRMQService {
 	}
 
 	private async listen(channel: Channel) {
-		await channel.assertQueue(this.options.queueName, {
+		const queue = await channel.assertQueue(this.options.queueName, {
 			durable: this.options.isQueueDurable ?? true,
+			exclusive: this.options.isQueueExclusive ?? !this.options.queueName,
 			arguments: this.options.queueArguments ?? {},
 		});
+		this.options.queueName = queue.queue;
+
 		await this.bindRMQRoutes(channel);
 		await channel.consume(
 			this.options.queueName,


### PR DESCRIPTION
Regarding #43 