### PR TITLE
Feature/config auto bind routes

### DIFF
--- a/lib/interfaces/rmq-options.interface.ts
+++ b/lib/interfaces/rmq-options.interface.ts
@@ -43,6 +43,7 @@ export interface IRMQServiceOptions {
 	intercepters?: typeof RMQIntercepterClass[];
 	errorHandler?: typeof RMQErrorHandler;
 	serviceName?: string;
+	autoBindingRoutes?: boolean;
 }
 
 export interface IRMQConnection {

--- a/lib/rmq.service.ts
+++ b/lib/rmq.service.ts
@@ -215,8 +215,11 @@ export class RMQService implements OnModuleInit, IRMQService {
 			...this.options.queueOptions
 		});
 		this.options.queueName = queue.queue;
+		this.routes = this.metadataAccessor.getAllRMQPaths();
 
+		if (this.options.autoBindingRoutes ?? true)
 		await this.bindRMQRoutes(channel);
+
 		await channel.consume(
 			this.options.queueName,
 			async (msg: Message) => {
@@ -234,7 +237,6 @@ export class RMQService implements OnModuleInit, IRMQService {
 	}
 
 	private async bindRMQRoutes(channel: Channel): Promise<void> {
-		this.routes = this.metadataAccessor.getAllRMQPaths();
 		if (this.routes.length > 0) {
 			this.routes.map(async (r) => {
 				this.logger.log(`Mapped ${r}`, 'RMQRoute');

--- a/lib/rmq.service.ts
+++ b/lib/rmq.service.ts
@@ -218,7 +218,7 @@ export class RMQService implements OnModuleInit, IRMQService {
 		this.routes = this.metadataAccessor.getAllRMQPaths();
 
 		if (this.options.autoBindingRoutes ?? true)
-		await this.bindRMQRoutes(channel);
+			await this.bindRMQRoutes(channel);
 
 		await channel.consume(
 			this.options.queueName,


### PR DESCRIPTION
Hi.

We are pushing a new feature, that add a option for disable auto mapping routing keys. We know, some cases, routing configuration are done on rabbit side, and auto binding is not needed.