### PR TITLE
fix: throw error on auth with wrong credentials

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -8,8 +8,11 @@ export const RMQ_MODULE_OPTIONS = 'RMQ_MODULE_OPTIONS';
 
 export const DISCONNECT_EVENT = 'disconnect';
 export const CONNECT_EVENT = 'connect';
+export const CONNECT_FAILED = 'connectFailed';
 export const DISCONNECT_MESSAGE = 'Disconnected from RMQ. Trying to reconnect';
 export const CONNECTED_MESSAGE = 'Successfully connected to RMQ';
+export const CONNECT_FAILED_MESSAGE = 'Failed to connect to RMQ';
+export const WRONG_CREDENTIALS_MESSAGE = 'Wrong credentials for RMQ'; 
 export const REPLY_QUEUE = 'amq.rabbitmq.reply-to';
 export const ERROR_NONE_RPC = 'This is none RPC queue. Use notify() method instead';
 export const ERROR_NO_ROUTE = "Requested service doesn't have RMQRoute with this path";


### PR DESCRIPTION
This pull request adds improved error handling for connection failures in the RMQService class. A check has been added to handle the CONNECT_FAILED event, specifically addressing scenarios related to wrong credentials or access refusal. The code snippet provided handles these cases by logging appropriate error messages and rejecting the promise.

```javascript
this.server.on(CONNECT_FAILED, (err) => {
    this.logger.error(CONNECT_FAILED_MESSAGE);
    this.logger.error(err.err);
    if (err.err.message.includes('ACCESS-REFUSED') || err.err.message.includes('403')) {
        this.logger.error(WRONG_CREDENTIALS_MESSAGE);
        reject(err);
    }
});
```

Please review the changes and let me know if any further modifications or adjustments are required.