### PR TITLE
Update rmq.explorer.ts

### DIFF
--- a/lib/rmq.explorer.ts
+++ b/lib/rmq.explorer.ts
@@ -40,9 +40,8 @@ export class RMQExplorer implements OnModuleInit {
 				return;
 			}
 
-			this.metadataScanner.scanFromPrototype(instance, Object.getPrototypeOf(instance), (key: string) =>
-				this.lookupRMQRoute(instance, key)
-			);
+			this.metadataScanner.getAllMethodNames(Object.getPrototypeOf(instance))
+				.map((key) => this.lookupRMQRoute(instance, key));
 		});
 	}
 


### PR DESCRIPTION
Hi 👋 
scanFromPrototype is deprecated.
Changed to getAllMethodNames. 🙂